### PR TITLE
Add verification to Conekta Tokenization process

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_conekta_card.js
+++ b/app/assets/javascripts/spree/frontend/solidus_conekta_card.js
@@ -9,17 +9,16 @@ $(document).ready(function() {
   var conektaErrorResponseHandler = function(response) {
     var $form = $("#checkout_form_payment");
     $form.find(".card-errors").text(response.message_to_purchaser);
-    $form.find("button").prop("disabled", false);
   };
 
   //jQuery generate the token on submit.
   $(function () {
     $("#checkout_form_payment").submit(function(event) {
       var $form = $(this);
-      // Prevents double clic
-      $form.find("button").prop("disabled", true);
-      Conekta.Token.create($form, conektaSuccessResponseHandler, conektaErrorResponseHandler);
-      return false;
+      if ($(creditCardPaymentId).prop('checked')) {
+        Conekta.Token.create($form, conektaSuccessResponseHandler, conektaErrorResponseHandler);
+        return false;
+      }
     });
   });
 });

--- a/app/views/spree/admin/payments/source_forms/_conekta_card.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_conekta_card.html.erb
@@ -51,5 +51,6 @@
                     data: { conekta: 'card[exp_year]' }) %>
   </div>
   <%= javascript_tag do %>
+    var creditCardPaymentId = '#order_payments_attributes__payment_method_id_<%= payment_method.id %>'
     Conekta.setPublicKey('<%= payment_method.preferences[:public_auth_token] %>');
   <% end  %>

--- a/app/views/spree/checkout/payment/_conekta_card.html.erb
+++ b/app/views/spree/checkout/payment/_conekta_card.html.erb
@@ -52,5 +52,6 @@
   </div>
 
 <%= javascript_tag do %>
+  var creditCardPaymentId = '#order_payments_attributes__payment_method_id_<%= payment_method.id %>'
   Conekta.setPublicKey('<%= payment_method.preferences[:public_auth_token] %>');
 <% end  %>


### PR DESCRIPTION
Quick info
---
This change introduces a verification on the form submit event by
checking if the Conekta Credit Card payment method radio button is
checked.

Migrations?
---
:-1: 

What does this change?
---
It modifies the Conekta Tokenization process by adding a verification before launching it.

Why are you changing that?
---
Because the Conekta Tokenization process was being launched every time the user submits the payment form even when the user selected another payment method since the payment method form id is the same for all payment methods.

How did you accomplish this change?
---
It creates a `creditCardPaymentId` variable to hold the ID of the Conekta Card Payment method radio button in order use this value to verify if it is checked when the form is submitted, if it is, then launch the tokenization process.

Merge/Deploy Checklist
---
- [x] It has been reviewed and accepted.
