### PR TITLE
Add missing translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,24 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  activerecord:
-    attributes:
-      spree/gateway/conekta_card_gateway:
-        number: Card Number
+  spree:
+    conekta_card_gateway: 'Conekta payments:'
+    activerecord:
+      attributes:
+        spree/gateway/conekta_card_gateway:
+          number: Card number
+          month: Month
+          verification_value: Verification number
+          year: Year
+      errors:
+        models:
+          spree/gateway/conekta_card_gateway:
+            attributes:
+              month:
+                not_a_number: Is not a number
+              year:
+                not_a_number: Is not a number
+              number:
+                blank: Is blank
+              verification_value:
+                blank: Is blank

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,6 +1,23 @@
 
 es-MX:
+  spree:
+    conekta_card_gateway: 'Conekta pagos:'
   activerecord:
     attributes:
       spree/gateway/conekta_card_gateway:
-        number: Numero de Tarjeta
+        number: Número de Tarjeta
+        month: Mes
+        verification_value: Número de verificación
+        year: Año
+    errors:
+      models:
+        spree/gateway/conekta_card_gateway:
+          attributes:
+            month:
+              not_a_number: No es numérico
+            year:
+              not_a_number: No es numérico
+            number:
+              blank: Está vacío
+            verification_value:
+              blank: Está vacío


### PR DESCRIPTION
Added some missing keys in the `en.yml` and `es-MX.yml` locales
in order to fix the messages of missing translations from the form in the validation error messages.
![image](https://user-images.githubusercontent.com/3879353/62814448-880f9100-bad6-11e9-9faf-a7cb31a8de94.png)
